### PR TITLE
TASK: Use modern API to copy to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ prototype(Neos.Neos:ConvertUris) {
 
 ## Usage
 
-After installation you will find an additional icon in the 
+After installation you will find an additional icon in the
 workspace module of your Neos installation. As Administrator
 you will be able to create a preview link for an existing internal workspace.
+
 Any editor can then use the second menu option to copy that link and give it to
 people who should preview the workspace.

--- a/Resources/Private/Templates/Module/Management/Workspaces/Index.html
+++ b/Resources/Private/Templates/Module/Management/Workspaces/Index.html
@@ -187,59 +187,11 @@
 	</div>
 	<script>
 		function copyTextToClipboard(text) {
-			var textArea = document.createElement("textarea");
-
-			//
-			// *** This styling is an extra step which is likely not required. ***
-			//
-			// Why is it here? To ensure:
-			// 1. the element is able to have focus and selection.
-			// 2. if element was to flash render it has minimal visual impact.
-			// 3. less flakyness with selection and copying which **might** occur if
-			//    the textarea element is not visible.
-			//
-			// The likelihood is the element won't even render, not even a flash,
-			// so some of these are just precautions. However in IE the element
-			// is visible whilst the popup box asking the user for permission for
-			// the web page to copy to the clipboard.
-			//
-
-			// Place in top-left corner of screen regardless of scroll position.
-			textArea.style.position = 'fixed';
-			textArea.style.top = 0;
-			textArea.style.left = 0;
-
-			// Ensure it has a small width and height. Setting to 1px / 1em
-			// doesn't work as this gives a negative w/h on some browsers.
-			textArea.style.width = '2em';
-			textArea.style.height = '2em';
-
-			// We don't need padding, reducing the size if it does flash render.
-			textArea.style.padding = 0;
-
-			// Clean up any borders.
-			textArea.style.border = 'none';
-			textArea.style.outline = 'none';
-			textArea.style.boxShadow = 'none';
-
-			// Avoid flash of white box if rendered for any reason.
-			textArea.style.background = 'transparent';
-
-
-			textArea.value = text;
-
-			document.body.appendChild(textArea);
-			textArea.focus();
-			textArea.select();
-
-			try {
-				document.execCommand('copy');
-			} catch (err) {
-				console.log('Unable to copy.');
-			}
-
-			document.body.removeChild(textArea);
+			navigator.clipboard.writeText(text).then(function () {
+				console.log('Copied preview link.');
+			}, function () {
+				console.log('Unable to copy preview link.');
+			});
 		}
-
 	</script>
 </f:section>


### PR DESCRIPTION
Use `navigator.clipboard.writeText()` instead of the deprecated
`document.execCommand('copy')`. MSIE users will need to copy the
link manually now, but 🤷‍♂️