### PR TITLE
TASK: Redirect after token (re-)generation

### DIFF
--- a/Classes/Controller/HashTokenRefreshController.php
+++ b/Classes/Controller/HashTokenRefreshController.php
@@ -22,12 +22,11 @@ class HashTokenRefreshController extends ActionController
      * Will refresh the hash or create an entirely new token for the given workspace
      *
      * @param Workspace $workspace
-     * @throws \Neos\Flow\Mvc\Exception\ForwardException
      */
-    public function refreshHashTokenForWorkspaceAction(Workspace $workspace)
+    public function refreshHashTokenForWorkspaceAction(Workspace $workspace): void
     {
         $this->workspacePreviewTokenFactory->refresh($workspace->getName());
         $this->addFlashMessage('A new preview token has been generated for workspace "%s", the old one is invalid now!', '', Message::SEVERITY_OK, [$workspace->getTitle()]);
-        $this->forwardToReferringRequest();
+        $this->redirectToRequest($this->request->getReferringRequest());
     }
 }


### PR DESCRIPTION
The use of `forwardToReferringRequest()` left the URL to the token
(re-)generation in the URL, so that a reload would lead to unexpected
action.

The use of a redirect fixes that.