### PR TITLE
BUGFIX: Only hide invisible content if in preview mode AND user is authenticated as workspace previewer

### DIFF
--- a/Classes/Aspects/NodeConverterAspect.php
+++ b/Classes/Aspects/NodeConverterAspect.php
@@ -37,11 +37,9 @@ class NodeConverterAspect
 
         try {
             if (
-                $workspaceName !== 'live'
-                && (
-                    $this->userInterfaceModeService->findModeByCurrentUser()->isPreview()
-                    || $this->securityContext->hasRole('Flownative.WorkspacePreview:WorkspacePreviewer')
-                )
+                $workspaceName !== 'live' &&
+                $this->securityContext->hasRole('Flownative.WorkspacePreview:WorkspacePreviewer') &&
+                $this->userInterfaceModeService->findModeByCurrentUser()->isPreview()
             ) {
                 $contextProperties['invisibleContentShown'] = false;
             }


### PR DESCRIPTION
Reduce the scope of the aspect to avoid problems in other endpoints, like the UI endpoint `getAdditionalNodeMetaDataAction()`

fixes #46 