### PR TITLE
UI-Mode switcher

### DIFF
--- a/Classes/Aspects/PreviewModeSwitchingAspect.php
+++ b/Classes/Aspects/PreviewModeSwitchingAspect.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Flownative\WorkspacePreview\Aspects;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Security\Context;
+use Neos\Neos\Domain\Service\UserInterfaceModeService;
+use Neos\Neos\Domain\Service\UserService;
+
+/**
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class PreviewModeSwitchingAspect
+{
+    const PREVIOUS_MODE_KEY = 'flownative.workspacePreview.previousEditPreviewMode';
+
+    /**
+     * @Flow\Inject
+     * @var Context
+     */
+    protected $securityContext;
+
+    /**
+     * @Flow\Inject
+     * @var UserInterfaceModeService
+     */
+    protected $userInterfaceModeService;
+
+    /**
+     * @FLow\Inject
+     * @var UserService
+     */
+    protected $userService;
+
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
+
+    /**
+     * @Flow\InjectConfiguration()
+     * @var array
+     */
+    protected array $settings;
+
+
+    /**
+     * @Flow\Around("method(Neos\Neos\Ui\Controller\BackendController->indexAction())")
+     * @param \Neos\Flow\Aop\JoinPointInterface $joinPoint The current join point
+     */
+    public function backendEntryJoinPoint(JoinPointInterface $joinPoint)
+    {
+        $this->switchPreviewMode($joinPoint);
+        return $joinPoint->getAdviceChain()->proceed($joinPoint);
+    }
+
+
+    /**
+     * @Flow\Around("method(Neos\Neos\Controller\Frontend\NodeController->previewAction())")
+     * @param \Neos\Flow\Aop\JoinPointInterface $joinPoint The current join point
+     */
+    public function previewRouteJoinPoint(JoinPointInterface $joinPoint)
+    {
+        $this->switchPreviewMode($joinPoint);
+        return $joinPoint->getAdviceChain()->proceed($joinPoint);
+
+    }
+
+
+    /**
+     * @param JoinPointInterface $joinPoint
+     * @return void
+     */
+    public function switchPreviewMode(JoinPointInterface $joinPoint): void
+    {
+        if ($this->settings['userInterfaceModeSwitcher']['enabled'] !== true) {
+            return;
+        }
+
+        $methodArguments = $joinPoint->getMethodArguments();
+        if (!$methodArguments['node'] instanceof NodeInterface) {
+            return;
+        }
+
+        /** @var NodeInterface $node */
+        $node = $methodArguments['node'];
+
+        $user = $this->userService->getCurrentUser();
+
+        if ($user !== null) {
+            $userPreferences = $user->getPreferences()->getPreferences();
+
+            if (str_starts_with($node->getContext()->getWorkspaceName(), 'user-')) {
+                //Reset to previous editPreviewMode
+                if (isset($userPreferences[self::PREVIOUS_MODE_KEY])) {
+                    $userPreferences['contentEditing.editPreviewMode'] = $userPreferences[self::PREVIOUS_MODE_KEY];
+                    unset($userPreferences[self::PREVIOUS_MODE_KEY]);
+                }
+            } elseif (!isset($userPreferences[self::PREVIOUS_MODE_KEY])) {
+                //Set editPreviewMode
+                $userPreferences[self::PREVIOUS_MODE_KEY] = $userPreferences['contentEditing.editPreviewMode'] ?: $this->userInterfaceModeService->findDefaultMode()->getName();
+                $userPreferences['contentEditing.editPreviewMode'] = $this->settings['userInterfaceModeSwitcher']['previewMode'];
+            } else {
+                return;
+            }
+
+            $newUserPreferences = clone $user->getPreferences();
+            $newUserPreferences->setPreferences($userPreferences);
+
+            $user->setPreferences($newUserPreferences);
+            $this->userService->updateUser($user);
+            $this->persistenceManager->persistAll();
+        }
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -42,3 +42,8 @@ Neos:
 Flownative:
   TokenAuthentication:
     authenticationProviderName: 'Flownative.WorkspacePreview:TokenAuthenticator'
+
+  WorkspacePreview:
+    userInterfaceModeSwitcher:
+      enabled: false
+      previewMode: 'desktop'

--- a/README.md
+++ b/README.md
@@ -29,3 +29,24 @@ Any editor can then use the second menu option to copy that link and give it to
 people who should preview the workspace.
 
 The package also creates separate preview links for every pages in a workspace. These can be found by going to the metadata tab in the inspector and opening additional information, which now contains a button for the preview link.
+
+
+## User-Interface Mode switcher
+Some Neos websites render editor hints or other backend-specific features, depending on the user interface mode.
+Due to Neos' preview logic, these also end up in the preview of this package.
+To prevent this, the `userInterfaceModeSwitcher` can be enabled. This sets the UI mode (selectable in the backend) to the desktop preview in the frontend and thus prevents the display of backend-specific renderings.
+Enabling the feature:
+```yaml
+Flownative:
+  WorkspacePreview:
+    userInterfaceModeSwitcher:
+      enabled: true
+```
+To customize the mode used for preview:
+```yaml
+Flownative:
+  WorkspacePreview:
+    userInterfaceModeSwitcher:
+      enabled: true
+      previewMode: '<mode-name>'
+```


### PR DESCRIPTION
We started using this Package for preview of internal Workspaces. It almost fits all of our requirements, but if a User was logged in and used the preview Link, the Neos-User becomes authenticated and Editor-Hints and other Backend-related stuff gets rendered. 

So we startet to implement an automatic aspect, wich switched the UI-Mode on using the preview and back, when doing something in Backend.   
Since this could be a use-case for more people, we decided to share this as configurable feature in this Package. 

Would be great, to have it directly implemented within the Package.